### PR TITLE
Fix takeaway image to firefox

### DIFF
--- a/src/styles/_takeaway.scss
+++ b/src/styles/_takeaway.scss
@@ -170,7 +170,9 @@
         }
 
         &--image {
-            max-height: 450px;
+            max-height: 400px;
+            width: auto;
+            max-width: 100%;
         }
 
         &--status-label {


### PR DESCRIPTION
Correspondence to the problem that the image of the drink menu was distorted in FireFox.